### PR TITLE
Error when graphite returns only one value

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -88,7 +88,7 @@ for d in mdata:
   try:
     pieces = d.split("|")
     counter = pieces[0].split(",")[0]
-    values = pieces[1].split(",")[:-1]
+    values = pieces[1].split(",")
   except:
     graphite.unknown_error("Graphite returned bad data")
 


### PR DESCRIPTION
Hi,
two small changes. Don't know if they make sense.
First use /usr/bin/env python, so the script works with virtualenv
Second, i had my graphite return metrics with only one datapoint in the requested time range, then the script fails, with "Graphite returned an empty list of values". I wonder if the construct in line 91 is anyhow useful.

I send you the pull request, because datacratic stopped supporting this script.

Best regards!
